### PR TITLE
Add glide and Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .env
 slack-mention-converter
 data
+
+/vendor

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,54 @@
+NAME := slack-mention-converter
+VERSION := 0.1.0
+REVISION := $(shell git rev-parse --short HEAD)
+
+LDFLAGS := -ldflags="-s -w -X \"main.Version=$(VERSION)\" -X \"main.Revision=$(REVISION)\""
+
+DIST_DIRS := find * -type d -exec
+
+DOCKER_REPOSITORY := quay.io
+DOCKER_IMAGE_NAME := $(DOCKER_REPOSITORY)/wantedly/slack-mention-converter
+DOCKER_IMAGE_TAG ?= latest
+DOCKER_IMAGE := $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)
+
+.DEFAULT_GOAL := bin/$(NAME)
+
+bin/$(NAME): deps
+	go build $(LDFLAGS) -o bin/$(NAME)
+
+.PHONY: ci-docker-release
+ci-docker-release: docker-build
+	@docker login -e="$(DOCKER_QUAY_EMAIL)" -u="$(DOCKER_QUAY_USERNAME)" -p="$(DOCKER_QUAY_PASSWORD)" $(DOCKER_REPOSITORY)
+	docker push $(DOCKER_IMAGE)
+
+.PHONY: clean
+clean:
+	rm -rf bin/*
+	rm -rf dist/*
+	rm -rf vendor/*
+
+.PHONY: deps
+deps: glide
+	glide install
+
+.PHONY: docker-build
+docker-build:
+	docker build -t $(DOCKER_IMAGE) .
+
+.PHONY: docker-push
+docker-push:
+	docker push $(DOCKER_IMAGE)
+
+.PHONY: glide
+glide:
+ifeq ($(shell command -v glide 2> /dev/null),)
+	curl https://glide.sh/get | sh
+endif
+
+.PHONY: install
+install: deps
+	go install $(LDFLAGS)
+
+.PHONY: test
+test: deps
+	go test -v `glide novendor`

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Available commands are:
 ### Build
 
 ```
-docker build -t quay.io/wantedly/slack-mention-converter .
+$ make docker-build
 ```
 
 ### Run
@@ -59,10 +59,12 @@ docker run --rm \
 
 ## Install
 
-To install, use `go get`:
+To install, use `go get` and `make`:
 
 ```bash
 $ go get -d github.com/wantedly/slack-mention-converter
+$ make
+$ make install
 ```
 
 ## Contribution

--- a/commands.go
+++ b/commands.go
@@ -37,7 +37,7 @@ func Commands(meta *command.Meta) map[string]cli.CommandFactory {
 			return &command.VersionCommand{
 				Meta:     *meta,
 				Version:  Version,
-				Revision: GitCommit,
+				Revision: Revision,
 				Name:     Name,
 			}, nil
 		},

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,20 @@
+hash: c86906e3da587e1569a222954181e8889dc01f14c48d54b937f04b4ebee552e3
+updated: 2016-09-20T16:37:33.712524478+09:00
+imports:
+- name: github.com/armon/go-radix
+  version: 4239b77079c7b5d1243b7b4736304ce8ddb6f0f2
+- name: github.com/bgentry/speakeasy
+  version: 36e9cfdd690967f4f690c6edcc9ffacd006014a0
+- name: github.com/jmoiron/jsonq
+  version: e874b168d07ecc7808bc950a17998a8aa3141d82
+- name: github.com/mattn/go-isatty
+  version: 56b76bdf51f7708750eac80fa38b952bb9f32639
+- name: github.com/mitchellh/cli
+  version: 168daae10d6ff81b8b1201b0a4c9607d7e9b82e3
+- name: golang.org/x/sys
+  version: a60af9cbbc6ab800af4f2be864a31f423a0ae1f2
+  subpackages:
+  - unix
+testImports:
+- name: github.com/joho/godotenv
+  version: a01a834e1654b4c9ca5b3ad05159445cc9c7ad08

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,6 @@
+package: github.com/wantedly/slack-mention-converter
+import:
+- package: github.com/jmoiron/jsonq
+- package: github.com/mitchellh/cli
+testImport:
+- package: github.com/joho/godotenv

--- a/version.go
+++ b/version.go
@@ -1,9 +1,8 @@
 package main
 
 const Name string = "slack-mention-converter"
-const Version string = "0.1.0"
 
-// GitCommit describes latest commit hash.
-// This value is extracted by git command when building.
-// To set this from outside, use go build -ldflags "-X main.GitCommit \"$(COMMIT)\""
-var GitCommit string
+var (
+	Version  string
+	Revision string
+)


### PR DESCRIPTION
## WHY

To standardize development environment
## WHAT

Manage dependencies by [glide](https://github.com/Masterminds/glide). Use `make` to build binary, install and build Docker image.
