### PR TITLE
Use DynamoDB instead of local CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ and add `bin/slack-mention-converter-linux-amd64` to the commit.
 
 ## Description
 
-Convert login_name or account_name to slack mention format.
+Convert login_name or account_name to slack mention format. Mappings of login_name and account_name are stored at Amazon DynamoDB.
 
 The most simple example usage is
 
@@ -25,6 +25,14 @@ $ slack-mention-converter to-slack-mention your_login_name
 ```
 
 ## Usage
+
+### AWS configuration
+
+2 DynamoDB tables named `SlackNames` and `SlackIDs` must be created.
+
+In addition, `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` must be set beforehand at your shell. This IAM account must be allowed to read/write the DynamoDB tables above.
+
+### Command usage
 
 ```
 usage: slack-mention-converter [--version] [--help] <command> [<args>]

--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ $ slack-mention-converter to-slack-mention your_login_name
 #### `SlackNames` table
 
 |Key|Type| |
-|---|----|-|
+|---|----|---|
 |LoginName|String|Primary key|
 |SlackName|String||
 
 #### `SlackIDs` table
 
 |Key|Type| |
-|---|----|-|
+|---|----|---|
 |SlackName|String|Primary key|
 |SlackID|String||
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ $ slack-mention-converter to-slack-mention your_login_name
 
 2 DynamoDB tables named `SlackNames` and `SlackIDs` must be created.
 
+#### `SlackNames` table
+
+|Key|Type| |
+|---|----|-|
+|LoginName|String|Primary key|
+|SlackName|String||
+
+#### `SlackIDs` table
+
+|Key|Type| |
+|---|----|-|
+|SlackName|String|Primary key|
+|SlackID|String||
+
 In addition, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_REGION` must be set at your shell. This IAM user/role must be allowed to read/write the DynamoDB tables above.
 
 ### Command usage

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ slack-mention-converter to-slack-mention your_login_name
 
 2 DynamoDB tables named `SlackNames` and `SlackIDs` must be created.
 
-In addition, `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` must be set beforehand at your shell. This IAM account must be allowed to read/write the DynamoDB tables above.
+In addition, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_REGION` must be set at your shell. This IAM user/role must be allowed to read/write the DynamoDB tables above.
 
 ### Command usage
 
@@ -59,7 +59,9 @@ $ make docker-build
 ```
 docker run --rm \
   -e SLACK_API_TOKEN=<slack token get by https://api.slack.com/docs/oauth-test-tokens>  \
-  -v data:/data \
+  -e AWS_ACCESS_KEY_ID=yourawsaccesskeyid \
+  -e AWS_SECRET_ACCESS_KEY=yourawssecretaccesskey \
+  -e AWS_REGION=ap-northeast-1 \
   quay.io/wantedly/slack-mention-converter \
   <command>
 ```

--- a/command/list.go
+++ b/command/list.go
@@ -3,9 +3,12 @@ package command
 import (
 	"fmt"
 	"log"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/wantedly/slack-mention-converter/service"
+	"github.com/wantedly/slack-mention-converter/store"
 )
 
 type ListCommand struct {
@@ -13,7 +16,13 @@ type ListCommand struct {
 }
 
 func (c *ListCommand) Run(args []string) int {
-	users, err := service.ListUsers()
+	var s store.Store
+
+	dir, _ := os.Getwd()
+	dir = filepath.Join(dir, "data")
+	s = store.NewCSV(dir)
+
+	users, err := service.ListUsers(s)
 	if err != nil {
 		log.Println(err)
 		return 1

--- a/command/list.go
+++ b/command/list.go
@@ -3,8 +3,6 @@ package command
 import (
 	"fmt"
 	"log"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/wantedly/slack-mention-converter/service"
@@ -18,9 +16,10 @@ type ListCommand struct {
 func (c *ListCommand) Run(args []string) int {
 	var s store.Store
 
-	dir, _ := os.Getwd()
-	dir = filepath.Join(dir, "data")
-	s = store.NewCSV(dir)
+	// dir, _ := os.Getwd()
+	// dir = filepath.Join(dir, "data")
+	// s = store.NewCSV(dir)
+	s = store.NewDynamoDB()
 
 	users, err := service.ListUsers(s)
 	if err != nil {

--- a/command/register.go
+++ b/command/register.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/wantedly/slack-mention-converter/models"
@@ -31,9 +30,10 @@ func (c *RegisterCommand) Run(args []string) int {
 
 	var s store.Store
 
-	dir, _ := os.Getwd()
-	dir = filepath.Join(dir, "data")
-	s = store.NewCSV(dir)
+	// dir, _ := os.Getwd()
+	// dir = filepath.Join(dir, "data")
+	// s = store.NewCSV(dir)
+	s = store.NewDynamoDB()
 
 	user := models.NewUser(loginName, slackName)
 	err := service.AddUser(s, user)

--- a/command/register.go
+++ b/command/register.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/wantedly/slack-mention-converter/models"
 	"github.com/wantedly/slack-mention-converter/service"
 )
 
@@ -26,7 +27,7 @@ func (c *RegisterCommand) Run(args []string) int {
 		return 1
 	}
 
-	user := service.NewUser(loginName, slackName)
+	user := models.NewUser(loginName, slackName)
 	err := service.AddUser(user)
 	if err != nil {
 		log.Println(err)

--- a/command/register.go
+++ b/command/register.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/wantedly/slack-mention-converter/models"
 	"github.com/wantedly/slack-mention-converter/service"
+	"github.com/wantedly/slack-mention-converter/store"
 )
 
 type RegisterCommand struct {
@@ -27,8 +29,14 @@ func (c *RegisterCommand) Run(args []string) int {
 		return 1
 	}
 
+	var s store.Store
+
+	dir, _ := os.Getwd()
+	dir = filepath.Join(dir, "data")
+	s = store.NewCSV(dir)
+
 	user := models.NewUser(loginName, slackName)
-	err := service.AddUser(user)
+	err := service.AddUser(s, user)
 	if err != nil {
 		log.Println(err)
 		return 1

--- a/command/slack_name_list.go
+++ b/command/slack_name_list.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/wantedly/slack-mention-converter/service"
+	"github.com/wantedly/slack-mention-converter/store"
 )
 
 type SlackNameListCommand struct {
@@ -13,7 +14,14 @@ type SlackNameListCommand struct {
 }
 
 func (c *SlackNameListCommand) Run(args []string) int {
-	users, err := service.ListSlackUsers()
+	var s store.Store
+
+	// dir, _ := os.Getwd()
+	// dir = filepath.Join(dir, "data")
+	// s = store.NewCSV(dir)
+	s = store.NewDynamoDB()
+
+	users, err := service.ListSlackUsers(s)
 	if err != nil {
 		log.Println(err)
 		return 1

--- a/command/to_slack_mention.go
+++ b/command/to_slack_mention.go
@@ -3,9 +3,12 @@ package command
 import (
 	"fmt"
 	"log"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/wantedly/slack-mention-converter/service"
+	"github.com/wantedly/slack-mention-converter/store"
 )
 
 type ToSlackMentionCommand struct {
@@ -21,7 +24,13 @@ func (c *ToSlackMentionCommand) Run(args []string) int {
 		return 1
 	}
 
-	user, err := service.GetUser(loginName)
+	var s store.Store
+
+	dir, _ := os.Getwd()
+	dir = filepath.Join(dir, "data")
+	s = store.NewCSV(dir)
+
+	user, err := service.GetUser(s, loginName)
 	if err != nil {
 		slackName = loginName
 		log.Printf("Login name '%v' not found. Treat it as slack name\n", loginName)

--- a/command/to_slack_mention.go
+++ b/command/to_slack_mention.go
@@ -3,8 +3,6 @@ package command
 import (
 	"fmt"
 	"log"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/wantedly/slack-mention-converter/service"
@@ -26,9 +24,10 @@ func (c *ToSlackMentionCommand) Run(args []string) int {
 
 	var s store.Store
 
-	dir, _ := os.Getwd()
-	dir = filepath.Join(dir, "data")
-	s = store.NewCSV(dir)
+	// dir, _ := os.Getwd()
+	// dir = filepath.Join(dir, "data")
+	// s = store.NewCSV(dir)
+	s = store.NewDynamoDB()
 
 	user, err := service.GetUser(s, loginName)
 	if err != nil {

--- a/command/to_slack_mention.go
+++ b/command/to_slack_mention.go
@@ -36,7 +36,7 @@ func (c *ToSlackMentionCommand) Run(args []string) int {
 	} else {
 		slackName = user.SlackName
 	}
-	slackUser, err := service.GetSlackUser(slackName)
+	slackUser, err := service.GetSlackUser(s, slackName)
 	if err != nil {
 		log.Printf("%v. Slack Name: %v\n", err, slackName)
 		return 1

--- a/command/to_slack_name.go
+++ b/command/to_slack_name.go
@@ -3,9 +3,12 @@ package command
 import (
 	"fmt"
 	"log"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/wantedly/slack-mention-converter/service"
+	"github.com/wantedly/slack-mention-converter/store"
 )
 
 type ToSlackNameCommand struct {
@@ -21,7 +24,13 @@ func (c *ToSlackNameCommand) Run(args []string) int {
 		return 1
 	}
 
-	user, err := service.GetUser(loginName)
+	var s store.Store
+
+	dir, _ := os.Getwd()
+	dir = filepath.Join(dir, "data")
+	s = store.NewCSV(dir)
+
+	user, err := service.GetUser(s, loginName)
 	if err != nil {
 		log.Printf("Login name '%v' not found\n", loginName)
 		return 1

--- a/command/to_slack_name.go
+++ b/command/to_slack_name.go
@@ -3,8 +3,6 @@ package command
 import (
 	"fmt"
 	"log"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/wantedly/slack-mention-converter/service"
@@ -26,9 +24,10 @@ func (c *ToSlackNameCommand) Run(args []string) int {
 
 	var s store.Store
 
-	dir, _ := os.Getwd()
-	dir = filepath.Join(dir, "data")
-	s = store.NewCSV(dir)
+	// dir, _ := os.Getwd()
+	// dir = filepath.Join(dir, "data")
+	// s = store.NewCSV(dir)
+	s = store.NewDynamoDB()
 
 	user, err := service.GetUser(s, loginName)
 	if err != nil {

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,14 @@
-hash: c86906e3da587e1569a222954181e8889dc01f14c48d54b937f04b4ebee552e3
-updated: 2016-09-20T16:37:33.712524478+09:00
+hash: 2e387e83945a62be20fae0d1a6205db3c5e1105c6fa1b770db330c34afabb452
+updated: 2016-09-21T11:37:48.494296609+09:00
 imports:
 - name: github.com/armon/go-radix
   version: 4239b77079c7b5d1243b7b4736304ce8ddb6f0f2
+- name: github.com/aws/aws-sdk-go
+  version: 7a81396c57134038e554b2ac86be4653018b20f9
+  subpackages:
+  - aws
+  - aws/service/dynamodb
+  - aws/session
 - name: github.com/bgentry/speakeasy
   version: 36e9cfdd690967f4f690c6edcc9ffacd006014a0
 - name: github.com/jmoiron/jsonq

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,5 +2,11 @@ package: github.com/wantedly/slack-mention-converter
 import:
 - package: github.com/jmoiron/jsonq
 - package: github.com/mitchellh/cli
+- package: github.com/aws/aws-sdk-go
+  version: v1.4.11
+  subpackages:
+  - aws
+  - aws/session
+  - aws/service/dynamodb
 testImport:
 - package: github.com/joho/godotenv

--- a/models/slack_user.go
+++ b/models/slack_user.go
@@ -1,0 +1,23 @@
+package models
+
+import (
+	"fmt"
+)
+
+// SlackUser stores slack user name and id
+type SlackUser struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// NewSlackUser creates new SlackUser instance
+func NewSlackUser(id string, name string) *SlackUser {
+	return &SlackUser{
+		ID:   id,
+		Name: name,
+	}
+}
+
+func (u SlackUser) String() string {
+	return fmt.Sprintf("<@%v|%v>", u.ID, u.Name)
+}

--- a/models/slack_user.go
+++ b/models/slack_user.go
@@ -1,7 +1,16 @@
 package models
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/jmoiron/jsonq"
+)
+
+const (
+	slackUserListURL = "https://slack.com/api/users.list"
 )
 
 // SlackUser stores slack user name and id
@@ -16,6 +25,39 @@ func NewSlackUser(id string, name string) *SlackUser {
 		ID:   id,
 		Name: name,
 	}
+}
+
+// RetrieveFromSlack retrieves users via Slack API
+func RetrieveFromSlack(token string) ([]*SlackUser, error) {
+	if token == "" {
+		return nil, fmt.Errorf("You need to pass SLACK_API_TOKEN as environment variable")
+	}
+
+	requestURL := slackUserListURL + "?token=" + token
+	resp, err := http.Get(requestURL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	data := map[string]interface{}{}
+	dec := json.NewDecoder(resp.Body)
+	dec.Decode(&data)
+	jq := jsonq.NewQuery(data)
+	arr, err := jq.Array("members")
+	if err != nil {
+		return nil, err
+	}
+
+	var users []*SlackUser
+
+	for i := 0; i < len(arr); i++ {
+		id, _ := jq.String("members", strconv.Itoa(i), "id")
+		name, _ := jq.String("members", strconv.Itoa(i), "name")
+		users = append(users, NewSlackUser(id, name))
+	}
+
+	return users, nil
 }
 
 func (u *SlackUser) String() string {

--- a/models/slack_user.go
+++ b/models/slack_user.go
@@ -18,6 +18,6 @@ func NewSlackUser(id string, name string) *SlackUser {
 	}
 }
 
-func (u SlackUser) String() string {
+func (u *SlackUser) String() string {
 	return fmt.Sprintf("<@%v|%v>", u.ID, u.Name)
 }

--- a/models/user.go
+++ b/models/user.go
@@ -1,0 +1,23 @@
+package models
+
+import (
+	"fmt"
+)
+
+// User stores login user name and slack user name
+type User struct {
+	LoginName string
+	SlackName string
+}
+
+// NewUser creates new UserMap instance
+func NewUser(loginName string, slackName string) *User {
+	return &User{
+		LoginName: loginName,
+		SlackName: slackName,
+	}
+}
+
+func (u *User) String() string {
+	return fmt.Sprintf("%v:@%v", u.LoginName, u.SlackName)
+}

--- a/service/slack.go
+++ b/service/slack.go
@@ -1,128 +1,16 @@
 package service
 
 import (
-	"encoding/csv"
-	"encoding/json"
-	"errors"
-	"io"
-	"log"
-	"net/http"
-	"os"
-	"path/filepath"
-	"strconv"
-
-	"github.com/jmoiron/jsonq"
 	"github.com/wantedly/slack-mention-converter/models"
+	"github.com/wantedly/slack-mention-converter/store"
 )
-
-const (
-	// SlackUserListURL represents users.list Slack API endpoint (https://api.slack.com/methods/users.list)
-	SlackUserListURL = "https://slack.com/api/users.list"
-	// SlackUserCachePath is the file path to store slack users ids and names as csv
-	SlackUserCachePath = "data/slack_users.csv"
-)
-
-func cacheSlackUserFilePath() string {
-	curDir, _ := os.Getwd()
-	return filepath.Join(curDir, SlackUserCachePath)
-}
 
 // GetSlackUser returns slack user by its name
-func GetSlackUser(name string) (*models.SlackUser, error) {
-	slackUsers, err := getSlackUsersFromCache()
-	if err != nil {
-		return &models.SlackUser{}, err
-	}
-	for _, user := range slackUsers {
-		if user.Name == name {
-			return user, nil
-		}
-	}
-
-	slackUsers, err = fetchSlackUsers()
-	for _, user := range slackUsers {
-		if user.Name == name {
-			return user, nil
-		}
-	}
-	return &models.SlackUser{}, errors.New("Slack id not found")
+func GetSlackUser(s store.Store, name string) (*models.SlackUser, error) {
+	return s.GetSlackUser(name)
 }
 
 // ListSlackUsers returns slack user list
-func ListSlackUsers() ([]*models.SlackUser, error) {
-	cached, err := getSlackUsersFromCache()
-	if len(cached) > 0 {
-		return cached, err
-	}
-	return fetchSlackUsers()
-}
-
-func getSlackUsersFromCache() ([]*models.SlackUser, error) {
-	file, err := os.Open(cacheSlackUserFilePath())
-	if err != nil {
-		return []*models.SlackUser{}, err
-	}
-	defer file.Close()
-	reader := csv.NewReader(file)
-
-	var res []*models.SlackUser
-	for {
-		record, err := reader.Read()
-		if err == io.EOF {
-			break
-		} else if err != nil {
-			return res, err
-		}
-		res = append(res, models.NewSlackUser(record[0], record[1]))
-	}
-	return res, nil
-}
-
-func putSlackUsersToCache(slackUsers []*models.SlackUser) error {
-	file, err := os.OpenFile(cacheSlackUserFilePath(), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-	writer := csv.NewWriter(file)
-
-	for _, user := range slackUsers {
-		writer.Write([]string{user.ID, user.Name})
-	}
-	writer.Flush()
-	return nil
-}
-
-func fetchSlackUsers() ([]*models.SlackUser, error) {
-	token := os.Getenv("SLACK_API_TOKEN")
-	if token == "" {
-		log.Fatalf("You need to pass SLACK_API_TOKEN as environment variable.")
-	}
-	requestURL := SlackUserListURL + "?token=" + token
-	resp, err := http.Get(requestURL)
-	if err != nil {
-		return []*models.SlackUser{}, err
-	}
-	defer resp.Body.Close()
-
-	data := map[string]interface{}{}
-	dec := json.NewDecoder(resp.Body)
-	dec.Decode(&data)
-	jq := jsonq.NewQuery(data)
-	arr, err := jq.Array("members")
-	if err != nil {
-		log.Println(err)
-	}
-	var res []*models.SlackUser
-	for i := 0; i < len(arr); i++ {
-		id, _ := jq.String("members", strconv.Itoa(i), "id")
-		name, _ := jq.String("members", strconv.Itoa(i), "name")
-		res = append(res, models.NewSlackUser(id, name))
-	}
-
-	putErr := putSlackUsersToCache(res)
-	if putErr != nil {
-		log.Println(putErr)
-	}
-	return res, nil
+func ListSlackUsers(s store.Store) ([]*models.SlackUser, error) {
+	return s.ListSlackUsers()
 }

--- a/service/usermap.go
+++ b/service/usermap.go
@@ -1,85 +1,21 @@
 package service
 
 import (
-	"encoding/csv"
-	"errors"
-	"io"
-	"os"
-	"path/filepath"
-
 	"github.com/wantedly/slack-mention-converter/models"
+	"github.com/wantedly/slack-mention-converter/store"
 )
-
-var (
-	// UserMapCachePath is the file path to store login name and slack name pairs as csv
-	UserMapCachePath = "data/user_map.csv"
-)
-
-func cacheFileUserMapPath() string {
-	curDir, _ := os.Getwd()
-	return filepath.Join(curDir, UserMapCachePath)
-}
 
 // GetUser returns user by login name
-func GetUser(loginName string) (*models.User, error) {
-	users, err := ListUsers()
-	if err != nil {
-		return &models.User{}, err
-	}
-	for _, user := range users {
-		if user.LoginName == loginName {
-			return user, nil
-		}
-	}
-	return &models.User{}, errors.New("Such login name not found")
+func GetUser(s store.Store, loginName string) (*models.User, error) {
+	return s.GetUser(loginName)
 }
 
 // AddUser adds or replaces user
-func AddUser(user *models.User) error {
-	users, _ := ListUsers()
-	for i := 0; i < len(users); i++ {
-		if users[i].LoginName == user.LoginName {
-			users[i] = user
-			return putUsers(users)
-		}
-	}
-	users = append(users, user)
-	return putUsers(users)
+func AddUser(s store.Store, user *models.User) error {
+	return s.AddUser(user)
 }
 
 // ListUsers returns user list
-func ListUsers() ([]*models.User, error) {
-	file, err := os.Open(cacheFileUserMapPath())
-	if err != nil {
-		return []*models.User{}, nil
-	}
-	defer file.Close()
-	reader := csv.NewReader(file)
-
-	var res []*models.User
-	for {
-		record, err := reader.Read()
-		if err == io.EOF {
-			break
-		} else if err != nil {
-			return res, err
-		}
-		res = append(res, models.NewUser(record[0], record[1]))
-	}
-	return res, nil
-}
-
-func putUsers(users []*models.User) error {
-	file, err := os.OpenFile(cacheFileUserMapPath(), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-	writer := csv.NewWriter(file)
-
-	for _, user := range users {
-		writer.Write([]string{user.LoginName, user.SlackName})
-	}
-	writer.Flush()
-	return nil
+func ListUsers(s store.Store) ([]*models.User, error) {
+	return s.ListUsers()
 }

--- a/service/usermap_test.go
+++ b/service/usermap_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/wantedly/slack-mention-converter/models"
 )
 
 func randomString() string {
@@ -34,17 +36,17 @@ func TestUserFlow(t *testing.T) {
 		t.Fatalf("0 users should be present in initial state")
 	}
 
-	err = AddUser(User{"awakia", "naoyoshi"})
+	err = AddUser(&models.User{"awakia", "naoyoshi"})
 	if err != nil {
 		t.Errorf("%v", err)
 	}
 
-	err = AddUser(User{"kawasy", "yoshi"})
+	err = AddUser(&models.User{"kawasy", "yoshi"})
 	if err != nil {
 		t.Errorf("%v", err)
 	}
 
-	err = AddUser(User{"awakia", "nao"})
+	err = AddUser(&models.User{"awakia", "nao"})
 	if err != nil {
 		t.Errorf("%v", err)
 	}
@@ -56,11 +58,11 @@ func TestUserFlow(t *testing.T) {
 	if len(users) != 2 {
 		t.Fatalf("2 users should be present after adding users but %v users", len(users))
 	}
-	if (users[0] != User{"awakia", "nao"}) {
-		t.Errorf("users[0] should be :%#v, but: %#v", User{"awakia", "nao"}, users[0])
+	if (users[0] != &models.User{"awakia", "nao"}) {
+		t.Errorf("users[0] should be :%#v, but: %#v", &models.User{"awakia", "nao"}, users[0])
 	}
-	if (users[1] != User{"kawasy", "yoshi"}) {
-		t.Errorf("users[1] should be :%#v, but: %#v", User{"kawasy", "yoshi"}, users[1])
+	if (users[1] != &models.User{"kawasy", "yoshi"}) {
+		t.Errorf("users[1] should be :%#v, but: %#v", &models.User{"kawasy", "yoshi"}, users[1])
 	}
 
 	user, err := GetUser("awakia")
@@ -68,8 +70,8 @@ func TestUserFlow(t *testing.T) {
 		t.Errorf("%v", err)
 	}
 
-	if (user != User{"awakia", "nao"}) {
-		t.Errorf("user should be :%#v, but: %#v", User{"awakia", "nao"}, user)
+	if (user != &models.User{"awakia", "nao"}) {
+		t.Errorf("user should be :%#v, but: %#v", &models.User{"awakia", "nao"}, user)
 	}
 	teardown()
 }

--- a/store/csv.go
+++ b/store/csv.go
@@ -1,0 +1,88 @@
+package store
+
+import (
+	"encoding/csv"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/wantedly/slack-mention-converter/models"
+)
+
+const userMapName = "user_map.csv"
+
+type CSV struct {
+	dir string
+}
+
+func NewCSV(dir string) *CSV {
+	return &CSV{
+		dir: dir,
+	}
+}
+
+func (c *CSV) userMapPath() string {
+	return filepath.Join(c.dir, userMapName)
+}
+
+func (c *CSV) GetUser(loginName string) (*models.User, error) {
+	users, err := c.ListUsers()
+	if err != nil {
+		return &models.User{}, err
+	}
+	for _, user := range users {
+		if user.LoginName == loginName {
+			return user, nil
+		}
+	}
+	return &models.User{}, errors.New("Such login name not found")
+}
+
+func (c *CSV) AddUser(user *models.User) error {
+	users, _ := c.ListUsers()
+	for i := 0; i < len(users); i++ {
+		if users[i].LoginName == user.LoginName {
+			users[i] = user
+			return c.PutUsers(users)
+		}
+	}
+	users = append(users, user)
+	return c.PutUsers(users)
+}
+
+func (c *CSV) ListUsers() ([]*models.User, error) {
+	file, err := os.Open(c.userMapPath())
+	if err != nil {
+		return []*models.User{}, nil
+	}
+	defer file.Close()
+	reader := csv.NewReader(file)
+
+	var res []*models.User
+	for {
+		record, err := reader.Read()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return res, err
+		}
+		res = append(res, models.NewUser(record[0], record[1]))
+	}
+	return res, nil
+}
+
+func (c *CSV) PutUsers(users []*models.User) error {
+	file, err := os.OpenFile(c.userMapPath(), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	writer := csv.NewWriter(file)
+
+	for _, user := range users {
+		writer.Write([]string{user.LoginName, user.SlackName})
+	}
+	writer.Flush()
+	return nil
+}

--- a/store/csv.go
+++ b/store/csv.go
@@ -52,11 +52,11 @@ func (c *CSV) AddUser(user *models.User) error {
 	for i := 0; i < len(users); i++ {
 		if users[i].LoginName == user.LoginName {
 			users[i] = user
-			return c.PutUsers(users)
+			return c.putUsers(users)
 		}
 	}
 	users = append(users, user)
-	return c.PutUsers(users)
+	return c.putUsers(users)
 }
 
 func (c *CSV) ListUsers() ([]*models.User, error) {
@@ -80,7 +80,7 @@ func (c *CSV) ListUsers() ([]*models.User, error) {
 	return res, nil
 }
 
-func (c *CSV) PutUsers(users []*models.User) error {
+func (c *CSV) putUsers(users []*models.User) error {
 	file, err := os.OpenFile(c.userMapPath(), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
 		return err

--- a/store/csv.go
+++ b/store/csv.go
@@ -2,15 +2,24 @@ package store
 
 import (
 	"encoding/csv"
+	"encoding/json"
 	"errors"
 	"io"
+	"log"
+	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 
+	"github.com/jmoiron/jsonq"
 	"github.com/wantedly/slack-mention-converter/models"
 )
 
-const userMapName = "user_map.csv"
+const (
+	slackUserListURL = "https://slack.com/api/users.list"
+	slackIDsName     = "slack_users.csv"
+	userMapName      = "user_map.csv"
+)
 
 type CSV struct {
 	dir string
@@ -24,6 +33,10 @@ func NewCSV(dir string) *CSV {
 
 func (c *CSV) userMapPath() string {
 	return filepath.Join(c.dir, userMapName)
+}
+
+func (c *CSV) slackUsersPath() string {
+	return filepath.Join(c.dir, slackIDsName)
 }
 
 func (c *CSV) GetUser(loginName string) (*models.User, error) {
@@ -85,4 +98,102 @@ func (c *CSV) PutUsers(users []*models.User) error {
 	}
 	writer.Flush()
 	return nil
+}
+
+func (c *CSV) GetSlackUser(name string) (*models.SlackUser, error) {
+	slackUsers, err := c.getSlackUsersFromCache()
+	if err != nil {
+		return &models.SlackUser{}, err
+	}
+	for _, user := range slackUsers {
+		if user.Name == name {
+			return user, nil
+		}
+	}
+
+	slackUsers, err = c.fetchSlackUsers()
+	for _, user := range slackUsers {
+		if user.Name == name {
+			return user, nil
+		}
+	}
+	return &models.SlackUser{}, errors.New("Slack id not found")
+}
+
+func (c *CSV) ListSlackUsers() ([]*models.SlackUser, error) {
+	cached, err := c.getSlackUsersFromCache()
+	if len(cached) > 0 {
+		return cached, err
+	}
+	return c.fetchSlackUsers()
+}
+
+func (c *CSV) getSlackUsersFromCache() ([]*models.SlackUser, error) {
+	file, err := os.Open(c.slackUsersPath())
+	if err != nil {
+		return []*models.SlackUser{}, err
+	}
+	defer file.Close()
+	reader := csv.NewReader(file)
+
+	var res []*models.SlackUser
+	for {
+		record, err := reader.Read()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return res, err
+		}
+		res = append(res, models.NewSlackUser(record[0], record[1]))
+	}
+	return res, nil
+}
+
+func (c *CSV) putSlackUsersToCache(slackUsers []*models.SlackUser) error {
+	file, err := os.OpenFile(c.slackUsersPath(), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	writer := csv.NewWriter(file)
+
+	for _, user := range slackUsers {
+		writer.Write([]string{user.ID, user.Name})
+	}
+	writer.Flush()
+	return nil
+}
+
+func (c *CSV) fetchSlackUsers() ([]*models.SlackUser, error) {
+	token := os.Getenv("SLACK_API_TOKEN")
+	if token == "" {
+		log.Fatalf("You need to pass SLACK_API_TOKEN as environment variable.")
+	}
+	requestURL := slackUserListURL + "?token=" + token
+	resp, err := http.Get(requestURL)
+	if err != nil {
+		return []*models.SlackUser{}, err
+	}
+	defer resp.Body.Close()
+
+	data := map[string]interface{}{}
+	dec := json.NewDecoder(resp.Body)
+	dec.Decode(&data)
+	jq := jsonq.NewQuery(data)
+	arr, err := jq.Array("members")
+	if err != nil {
+		log.Println(err)
+	}
+	var res []*models.SlackUser
+	for i := 0; i < len(arr); i++ {
+		id, _ := jq.String("members", strconv.Itoa(i), "id")
+		name, _ := jq.String("members", strconv.Itoa(i), "name")
+		res = append(res, models.NewSlackUser(id, name))
+	}
+
+	putErr := c.putSlackUsersToCache(res)
+	if putErr != nil {
+		log.Println(putErr)
+	}
+	return res, nil
 }

--- a/store/dynamo_db.go
+++ b/store/dynamo_db.go
@@ -1,13 +1,19 @@
 package store
 
 import (
+	"os"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/wantedly/slack-mention-converter/models"
 )
 
-const userMapTable = "SlackUsers"
+const (
+	slackIDTable      = "SlackIDs"
+	userMapTable      = "SlackUsers"
+	batchWriteItemMax = 25
+)
 
 type DynamoDB struct {
 	db *dynamodb.DynamoDB
@@ -86,10 +92,126 @@ func (d *DynamoDB) PutUsers(users []*models.User) error {
 	return nil
 }
 
+func (d *DynamoDB) refreshSlackIDs(token string) error {
+	users, err := models.RetrieveFromSlack(token)
+	if err != nil {
+		return err
+	}
+
+	// BatchWriteItem accepts up to 25 items at the same time
+	for i := 0; i < len(users)/batchWriteItemMax+1; i++ {
+		var reqs []*dynamodb.WriteRequest
+		var last int
+
+		// e.g. 60 users are divided as: [0:25], [25:50], [50:60]
+		if len(users)-i*batchWriteItemMax >= batchWriteItemMax {
+			last = (i + 1) * batchWriteItemMax
+		} else {
+			last = len(users)
+		}
+
+		for _, u := range users[i*batchWriteItemMax : last] {
+			reqs = append(reqs, &dynamodb.WriteRequest{
+				PutRequest: &dynamodb.PutRequest{
+					Item: map[string]*dynamodb.AttributeValue{
+						"SlackName": {
+							S: aws.String(u.Name),
+						},
+						"SlackID": {
+							S: aws.String(u.ID),
+						},
+					},
+				},
+			})
+		}
+
+		reqItems := make(map[string][]*dynamodb.WriteRequest)
+		reqItems[slackIDTable] = reqs
+
+		_, err = d.db.BatchWriteItem(&dynamodb.BatchWriteItemInput{
+			RequestItems: reqItems,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (d *DynamoDB) retrieveUser(name string) (*models.SlackUser, error) {
+	resp, err := d.db.GetItem(&dynamodb.GetItemInput{
+		TableName: aws.String(slackIDTable),
+		Key: map[string]*dynamodb.AttributeValue{
+			"SlackName": {
+				S: aws.String(name),
+			},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return models.NewSlackUser(*resp.Item["SlackID"].S, name), nil
+}
+
+func (d *DynamoDB) retrieveUsers() ([]*models.SlackUser, error) {
+	resp, err := d.db.Scan(&dynamodb.ScanInput{
+		TableName: aws.String(slackIDTable),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var users []*models.SlackUser
+
+	for _, item := range resp.Items {
+		users = append(users, models.NewSlackUser(*item["SlackID"].S, *item["SlackName"].S))
+	}
+
+	return users, nil
+}
+
 func (d *DynamoDB) GetSlackUser(name string) (*models.SlackUser, error) {
-	return nil, nil
+	token := os.Getenv("SLACK_API_TOKEN")
+
+	user, err := d.retrieveUser(name)
+	if err == nil {
+		return user, nil
+	}
+
+	if err := d.refreshSlackIDs(token); err != nil {
+		return nil, err
+	}
+
+	user, err = d.retrieveUser(name)
+	if err == nil {
+		return user, nil
+	}
+
+	return nil, err
 }
 
 func (d *DynamoDB) ListSlackUsers() ([]*models.SlackUser, error) {
-	return nil, nil
+	token := os.Getenv("SLACK_API_TOKEN")
+
+	users, err := d.retrieveUsers()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(users) > 0 {
+		return users, nil
+	}
+
+	if err := d.refreshSlackIDs(token); err != nil {
+		return nil, err
+	}
+
+	users, err = d.retrieveUsers()
+	if err != nil {
+		return nil, err
+	}
+
+	return users, nil
 }

--- a/store/dynamo_db.go
+++ b/store/dynamo_db.go
@@ -40,10 +40,7 @@ func (d *DynamoDB) GetUser(loginName string) (*models.User, error) {
 		return nil, err
 	}
 
-	return &models.User{
-		LoginName: loginName,
-		SlackName: *resp.Item["SlackName"].S,
-	}, nil
+	return models.NewUser(loginName, *resp.Item["SlackName"].S), nil
 }
 
 func (d *DynamoDB) AddUser(user *models.User) error {

--- a/store/dynamo_db.go
+++ b/store/dynamo_db.go
@@ -1,0 +1,87 @@
+package store
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/wantedly/slack-mention-converter/models"
+)
+
+const userMapTable = "SlackUsers"
+
+type DynamoDB struct {
+	db *dynamodb.DynamoDB
+}
+
+func NewDynamoDB() *DynamoDB {
+	db := dynamodb.New(session.New(&aws.Config{}))
+
+	return &DynamoDB{
+		db: db,
+	}
+}
+
+func (d *DynamoDB) GetUser(loginName string) (*models.User, error) {
+	resp, err := d.db.GetItem(&dynamodb.GetItemInput{
+		TableName: aws.String(userMapTable),
+		Key: map[string]*dynamodb.AttributeValue{
+			"LoginName": {
+				S: aws.String(loginName),
+			},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &models.User{
+		LoginName: loginName,
+		SlackName: *resp.Item["SlackName"].S,
+	}, nil
+}
+
+func (d *DynamoDB) AddUser(user *models.User) error {
+	_, err := d.db.PutItem(&dynamodb.PutItemInput{
+		TableName: aws.String(userMapTable),
+		Item: map[string]*dynamodb.AttributeValue{
+			"LoginName": {
+				S: aws.String(user.LoginName),
+			},
+			"SlackName": {
+				S: aws.String(user.SlackName),
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *DynamoDB) ListUsers() ([]*models.User, error) {
+	resp, err := d.db.Scan(&dynamodb.ScanInput{
+		TableName: aws.String(userMapTable),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var users []*models.User
+
+	for _, item := range resp.Items {
+		users = append(users, models.NewUser(*item["LoginName"].S, *item["SlackName"].S))
+	}
+
+	return users, nil
+}
+
+func (d *DynamoDB) PutUsers(users []*models.User) error {
+	for _, user := range users {
+		if err := d.AddUser(user); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/store/dynamo_db.go
+++ b/store/dynamo_db.go
@@ -79,16 +79,6 @@ func (d *DynamoDB) ListUsers() ([]*models.User, error) {
 	return users, nil
 }
 
-func (d *DynamoDB) PutUsers(users []*models.User) error {
-	for _, user := range users {
-		if err := d.AddUser(user); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 func (d *DynamoDB) refreshSlackIDs(token string) error {
 	users, err := models.RetrieveFromSlack(token)
 	if err != nil {

--- a/store/dynamo_db.go
+++ b/store/dynamo_db.go
@@ -85,3 +85,11 @@ func (d *DynamoDB) PutUsers(users []*models.User) error {
 
 	return nil
 }
+
+func (d *DynamoDB) GetSlackUser(name string) (*models.SlackUser, error) {
+	return nil, nil
+}
+
+func (d *DynamoDB) ListSlackUsers() ([]*models.SlackUser, error) {
+	return nil, nil
+}

--- a/store/store.go
+++ b/store/store.go
@@ -9,4 +9,6 @@ type Store interface {
 	AddUser(user *models.User) error
 	ListUsers() ([]*models.User, error)
 	PutUsers(users []*models.User) error
+	GetSlackUser(name string) (*models.SlackUser, error)
+	ListSlackUsers() ([]*models.SlackUser, error)
 }

--- a/store/store.go
+++ b/store/store.go
@@ -8,7 +8,6 @@ type Store interface {
 	GetUser(loginName string) (*models.User, error)
 	AddUser(user *models.User) error
 	ListUsers() ([]*models.User, error)
-	PutUsers(users []*models.User) error
 	GetSlackUser(name string) (*models.SlackUser, error)
 	ListSlackUsers() ([]*models.SlackUser, error)
 }

--- a/store/store.go
+++ b/store/store.go
@@ -1,0 +1,12 @@
+package store
+
+import (
+	"github.com/wantedly/slack-mention-converter/models"
+)
+
+type Store interface {
+	GetUser(loginName string) (*models.User, error)
+	AddUser(user *models.User) error
+	ListUsers() ([]*models.User, error)
+	PutUsers(users []*models.User) error
+}


### PR DESCRIPTION
## WHY

Using local CSV is not scalable. We have to copy/share CSV files between multiple hosts.
## WHAT

Use external DynamoDB for Key-Value store.

At another pull request, I'll add flag to select CSV datastore the same until now.
