### PR TITLE
Install glibc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,11 @@ FROM alpine:3.4
 ENTRYPOINT ["bin/slack-mention-converter"]
 
 # enable to access slack api by https
-RUN apk --no-cache add ca-certificates
+RUN apk --no-cache add ca-certificates openssl
+RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub \
+    && wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.23-r3/glibc-2.23-r3.apk \
+    && apk add glibc-2.23-r3.apk \
+    && rm glibc-2.23-r3.apk
 
 VOLUME /data
 


### PR DESCRIPTION
## WHY

On OS X, `go build` builds _statically linked_ binary. However, on Linux (like Travis CI worker), `go build` generated _dynamically linked_ binary. We have to prepare glibc package if we use binary built on Linux machine.

```
# local
/ # file /bin/slack-mention-converter
/bin/slack-mention-converter: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, stripped

# travis
/ # file /bin/slack-mention-converter
/bin/slack-mention-converter: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, stripped
/ # ldd /bin/slack-mention-converter
        linux-vdso.so.1 (0x00007fff2359c000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fc83df4b000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fc83dba0000)
        /lib64/ld-linux-x86-64.so.2 (0x00005650bc51f000)
```
## WHAT

Install glibc in Docker image.
