### PR TITLE
Modify error handling

### DIFF
--- a/command/to_slack_mention.go
+++ b/command/to_slack_mention.go
@@ -15,12 +15,12 @@ type ToSlackMentionCommand struct {
 
 func (c *ToSlackMentionCommand) Run(args []string) int {
 	var loginName, slackName string
-	if len(args) == 1 {
-		loginName = args[0]
-	} else {
+	if len(args) != 1 {
 		log.Println(c.Help())
 		return 1
 	}
+
+	loginName = args[0]
 
 	var s store.Store
 

--- a/command/to_slack_mention.go
+++ b/command/to_slack_mention.go
@@ -33,9 +33,11 @@ func (c *ToSlackMentionCommand) Run(args []string) int {
 	if err != nil {
 		slackName = loginName
 		log.Printf("Login name '%v' not found. Treat it as slack name\n", loginName)
-	} else {
-		slackName = user.SlackName
+		return 1
 	}
+
+	slackName = user.SlackName
+
 	slackUser, err := service.GetSlackUser(s, slackName)
 	if err != nil {
 		log.Printf("%v. Slack Name: %v\n", err, slackName)

--- a/command/to_slack_name.go
+++ b/command/to_slack_name.go
@@ -15,12 +15,12 @@ type ToSlackNameCommand struct {
 
 func (c *ToSlackNameCommand) Run(args []string) int {
 	var loginName string
-	if len(args) == 1 {
-		loginName = args[0]
-	} else {
+	if len(args) != 1 {
 		log.Println(c.Help())
 		return 1
 	}
+
+	loginName = args[0]
 
 	var s store.Store
 


### PR DESCRIPTION
## WHAT
- Halt `to-slack-mention` command immediately if it failed to fetch Slack user
- Refacto if and return block
