### PR TITLE
Show error if failed to fetch from DynamoDB

### DIFF
--- a/command/to_slack_mention.go
+++ b/command/to_slack_mention.go
@@ -31,8 +31,8 @@ func (c *ToSlackMentionCommand) Run(args []string) int {
 
 	user, err := service.GetUser(s, loginName)
 	if err != nil {
-		slackName = loginName
 		log.Printf("Login name '%v' not found. Treat it as slack name\n", loginName)
+		log.Printf("Error: %v\n", err)
 		return 1
 	}
 


### PR DESCRIPTION
## WHY

Though converter fails to fetch data due to lack of authority, the only message below is shown.

```
2016/10/06 14:58:53 to_slack_mention.go:35: Login name 'dtan4' not found. Treat it as slack name
```

We cannot inspect the cause of this error from this message.
## WHAT

Print the whole caught error.
